### PR TITLE
feat: issue #2 systeminformationを使用したPCバッテリー残量確認ツールの実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,11 +11,13 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.15.0",
         "axios": "^1.10.0",
+        "systeminformation": "^5.25.3",
         "zod": "^3.25.76"
       },
       "devDependencies": {
         "@types/axios": "^0.9.36",
         "@types/node": "^24.0.10",
+        "@types/systeminformation": "^3.54.1",
         "@typescript-eslint/eslint-plugin": "^8.36.0",
         "@typescript-eslint/parser": "^8.36.0",
         "eslint": "^9.30.1",
@@ -1126,6 +1128,17 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.8.0"
+      }
+    },
+    "node_modules/@types/systeminformation": {
+      "version": "3.54.1",
+      "resolved": "https://registry.npmjs.org/@types/systeminformation/-/systeminformation-3.54.1.tgz",
+      "integrity": "sha512-vvisj2mdWygyc0jk/5XtSVq9gtxCmF3nrGwv8wVway8pwNRhtPji/MU9dc1L0F6rl0F/NFIHa4ScRU7wmNaHmg==",
+      "deprecated": "This is a stub types definition. systeminformation provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "systeminformation": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -3799,6 +3812,32 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/systeminformation": {
+      "version": "5.27.7",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.7.tgz",
+      "integrity": "sha512-saaqOoVEEFaux4v0K8Q7caiauRwjXC4XbD2eH60dxHXbpKxQ8kH9Rf7Jh+nryKpOUSEFxtCdBlSUx0/lO6rwRg==",
+      "license": "MIT",
+      "os": [
+        "darwin",
+        "linux",
+        "win32",
+        "freebsd",
+        "openbsd",
+        "netbsd",
+        "sunos",
+        "android"
+      ],
+      "bin": {
+        "systeminformation": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "Buy me a coffee",
+        "url": "https://www.buymeacoffee.com/systeminfo"
       }
     },
     "node_modules/tinybench": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.15.0",
     "axios": "^1.10.0",
+    "systeminformation": "^5.25.3",
     "zod": "^3.25.76"
   }
 }

--- a/src/mcp_server.ts
+++ b/src/mcp_server.ts
@@ -1,6 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import axios from 'axios';
+import * as si from 'systeminformation';
 
 // MCPサーバーの初期実装
 const server = new McpServer({
@@ -50,6 +51,52 @@ server.registerTool(
           {
             type: 'text',
             text: `エラーが発生しました: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+      };
+    }
+  }
+);
+
+// バッテリー残量取得ツールを登録
+server.registerTool(
+  'get_battery_status',
+  {
+    title: 'Get Battery Status',
+    description: 'PCのバッテリー残量を取得します',
+    inputSchema: {},
+  },
+  async () => {
+    try {
+      const batteryData = await si.battery();
+      const batteryPercent = batteryData.percent;
+      const isCharging = batteryData.isCharging;
+      const acConnected = batteryData.acConnected;
+      
+      let statusMessage = `バッテリー残量: ${batteryPercent}%`;
+      
+      if (isCharging) {
+        statusMessage += ' (充電中)';
+      } else if (acConnected) {
+        statusMessage += ' (AC電源接続中)';
+      } else {
+        statusMessage += ' (バッテリー駆動中)';
+      }
+      
+      return {
+        content: [
+          {
+            type: 'text',
+            text: statusMessage,
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `バッテリー情報の取得に失敗しました: ${error instanceof Error ? error.message : String(error)}`,
           },
         ],
       };


### PR DESCRIPTION
## 概要
issue #2で要求されたsysteminformationライブラリを使用したバッテリー残量確認ツールを実装しました。

## 実装内容
- systeminformationパッケージを追加
- mcp_server.tsにget_battery_statusツールを実装
- バッテリー残量（%）の取得機能
- 充電状態の判定機能（充電中/AC電源接続中/バッテリー駆動中）
- 日本語での結果表示機能
- エラーハンドリング

## 動作確認
- TypeScriptコンパイルが正常に完了
- MCPサーバーが正常に起動
- Inspectorでget_battery_statusツールが利用可能であることを確認

## 受け入れ条件
- [x] バッテリー残量が正常に取得できること
- [x] 日本語で結果が表示されること
- [x] エラー時に適切なメッセージが表示されること

🤖 Generated with [Claude Code](https://claude.ai/code)